### PR TITLE
Fix server startup guard for Flask app

### DIFF
--- a/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/app.py
+++ b/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/app.py
@@ -1294,10 +1294,10 @@ def venda_delete(sale_id):
 
 if __name__ == "__main__":
     check_files()
-    port = int(os.environ.get("PORT","5000"))
-    host = os.environ.get("HOST","127.0.0.1")
-    host = '127.0.0.1'
-port = _free_port(5000)
-url = f'http://{host}:{port}'
-_open_browser(url)
-app.run(host=host, port=port, debug=False, use_reloader=False)
+    port = int(os.environ.get("PORT", "5000"))
+    host = os.environ.get("HOST", "127.0.0.1")
+    host = "127.0.0.1"
+    port = _free_port(port)
+    url = f"http://{host}:{port}"
+    _open_browser(url)
+    app.run(host=host, port=port, debug=False, use_reloader=False)


### PR DESCRIPTION
## Summary
- wrap the dynamic port discovery and server startup logic under the __main__ guard so importing app.py no longer launches the server
- preserve environment overrides while still forcing the executable to bind to 127.0.0.1 and open the helper browser link

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce2b49ce948333a136a75e8da696b2